### PR TITLE
Syntax highlighting modification

### DIFF
--- a/system/parsedown.php
+++ b/system/parsedown.php
@@ -405,7 +405,15 @@ class Parsedown
 
             if (isset($matches[1]))
             {
-                $class = 'language-'.$matches[1];
+              $class = $matches[1];
+
+                $Element['attributes'] = array(
+                    'class' => $class,
+                );
+            }
+            else
+            {
+                $class = 'nohighlight';
 
                 $Element['attributes'] = array(
                     'class' => $class,


### PR DESCRIPTION
If using https://highlightjs.org/ the css class name need to have the language name only. Also added the class for no highlight as recommended.